### PR TITLE
Add leaderboards in app home

### DIFF
--- a/functions/appHome.js
+++ b/functions/appHome.js
@@ -3,6 +3,7 @@ const app = index.getBolt();
 
 const appHomeObjects = require('./appHomeObjects');
 const firestoreFuncs = require('./firestore');
+const leaderboard = require('./leaderboard');
 
 var days = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"];
 
@@ -174,6 +175,11 @@ async function loadHomeTabUI(app, workspaceID, userId, context) {
   }
   */
 
+	// get leaderboard strings
+	const leaderboards = await leaderboard.getLeaderboards(app, context.botToken, workspaceID);
+	const weeklyLeaderboard = leaderboards[0];
+	const monthlyLeaderboard = leaderboards[1];
+	
 	if(await checkOwner(workspaceID, userId)){
 		view = {
 			"type": "home",
@@ -470,6 +476,28 @@ async function loadHomeTabUI(app, workspaceID, userId, context) {
 					}
 				  },
 				{
+                    "type": "divider"
+                },
+                {
+                    "type": "section",
+                    "text":
+                    {
+                        "type": "mrkdwn",
+                        "text": weeklyLeaderboard
+                    }
+                },
+                {
+                    "type": "section",
+                    "text":
+                    {
+                        "type": "mrkdwn",
+                        "text": monthlyLeaderboard
+                    }
+				},
+				{
+                    "type": "divider"
+                },
+				{
 					"type": "context",
 					"elements": [
 						{
@@ -652,6 +680,25 @@ async function loadHomeTabUI(app, workspaceID, userId, context) {
 				{
 					"type": "divider"
 				},
+                {
+                    "type": "section",
+                    "text":
+                    {
+                        "type": "mrkdwn",
+                        "text": weeklyLeaderboard
+                    }
+                },
+                {
+                    "type": "section",
+                    "text":
+                    {
+                        "type": "mrkdwn",
+                        "text": monthlyLeaderboard
+                    }
+				},
+				{
+                    "type": "divider"
+                },
 				{
 					"type": "context",
 					"elements": [

--- a/functions/firestore.js
+++ b/functions/firestore.js
@@ -628,7 +628,6 @@ exports.getUserPairingData = async function getUserData(workspaceID, userID) {
         userID      - ID of user whose points will be incremented
 */
 exports.setPoints = async function setPoints(workspaceID, userID) {
-    //console.log("SETTING POINTS");
     let userDocRef = db.collection('workspaces')
                     .doc(workspaceID)
                     .collection('users')
@@ -650,7 +649,6 @@ exports.setPoints = async function setPoints(workspaceID, userID) {
         userID      - ID of user whose points will be reset
 */
 exports.resetWeeklyPoints = async function resetWeeklyPoints(workspaceID, userID) {
-    //console.log("RESET POINTS");
     let data = {
         weeklyPoints: 0
     };
@@ -658,7 +656,7 @@ exports.resetWeeklyPoints = async function resetWeeklyPoints(workspaceID, userID
                 .doc(workspaceID)
                 .collection('users')
                 .doc(userID)
-                .set(data);
+                .set(data, {merge: true});
 };
 
 /*
@@ -672,7 +670,6 @@ exports.resetWeeklyPoints = async function resetWeeklyPoints(workspaceID, userID
         userID      - ID of user whose points will be reset
 */
 exports.resetMonthlyPoints = async function resetMonthlyPoints(workspaceID, userID) {
-    //console.log("RESET POINTS");
     let data = {
         monthlyPoints: 0
     };
@@ -680,7 +677,7 @@ exports.resetMonthlyPoints = async function resetMonthlyPoints(workspaceID, user
                 .doc(workspaceID)
                 .collection('users')
                 .doc(userID)
-                .set(data);
+                .set(data, {merge: true});
 };
 
 /*

--- a/functions/firestore.js
+++ b/functions/firestore.js
@@ -1,7 +1,6 @@
 const functions = require('firebase-functions');
 const admin = require('firebase-admin');
 const request = require('request');
-const firestoreFuncs = require('./firestore');
 // const dotenv = require('dotenv');
 // dotenv.config();
 

--- a/functions/firestore.js
+++ b/functions/firestore.js
@@ -6,9 +6,9 @@ const request = require('request');
 
 // console.log(typeof(process.env.FUNCTIONS_EMULATOR));
 if(process.env.FUNCTIONS_EMULATOR === "true"){
-
+    
     var serviceAccount = require('./serviceAccountKey.json');
-
+    
     admin.initializeApp({
         credential: admin.credential.cert(serviceAccount),
         databaseURL: "https://altitest-5f53d.firebaseio.com"
@@ -21,75 +21,76 @@ else{
 let db = admin.firestore();
 
 
-/*
-    storeAPIPair(team_id, api_key):
+/* 
+    storeAPIPair(team_id, api_key): 
 
-    Stores the API keys from the database by team_id.
+    Stores the API keys from the database by team_id. 
 
-    @@PARAMS
-    team_id: same thing as workspace id
+    @@PARAMS 
+    team_id: same thing as workspace id 
 
-    store the API-tokens/id's in the format:
-        {
+    store the API-tokens/id's in the format: 
+        { 
             botToken: "xxxxxxxxxxxxx",
             botId: "Bxxxxxxxxx",
             botUserId: "Uxxxxxxxxx"
         })
  */
-exports.storeAPIPair = (team_id, api_key) => {
+exports.storeAPIPair = (team_id, api_key) => { 
 
     let setValue = {
         botToken: api_key.botToken,
         botId: api_key.botId,
         botUserId: api_key.botUserId
-    };
+    }; 
 
     console.log("Team ID: " + team_id);
-    console.log("API Keys: Copy/Paste this" + JSON.stringify(setValue, null, 1));
+    console.log("API Keys: Copy/Paste this" + JSON.stringify(setValue, null, 1)); 
     db.collection('api_keys').doc(team_id).set(setValue);
 };
 
-/*
+/* 
     getAPIPair(team_id):
 
-    Gets the API keys from the database by team_id.
+    Gets the API keys from the database by team_id. 
 
-    @@PARAMS
-    team_id: same thing as workspace id
+    @@PARAMS 
+    team_id: same thing as workspace id 
 
-    return the API-tokens/id's in the format:
-        {
+    return the API-tokens/id's in the format: 
+        { 
             botToken: "xxxxxxxxxxxxx",
             botId: "Bxxxxxxxxx",
             botUserId: "Uxxxxxxxxx"
         })
  */
-exports.getAPIPair = (team_id) => {
+exports.getAPIPair = (team_id) => { 
         return db.collection('api_keys').doc(team_id).get().then((doc) => {
-            if (!(doc && doc.exists)) {
+            if (!(doc && doc.exists)) {	
 
                 //verbose debug message
-
+                
                 if(process.env.FUNCTIONS_EMULATOR === "true") {
-                    console.log(" Your API_Key is not in the firestore db. " +
+                    console.log(" Your API_Key is not in the firestore db. " + 
                     "\nRemember that data does not save after restart."+
                     "\n You may have to reinstall your app again if you are using the emulator.");
 
-                } else {
-                    console.log("Your API_Key is not in the firestore db. ");
+                } else { 
+                    console.log("Your API_Key is not in the firestore db. "); 
                 }
-                return null;
+                return null;	
             }
-
-            //returns the fetched value here
+            
+            //returns the fetched value here 
             return doc.data();
-        }).catch(() => {
+        }).catch(() => {	
             //return null if there was an error in fetching the data
             return null;
         });
 };
 
-/*
+
+/* 
     Stores the new pairings (DM thread ids + partnerIDs) in the corresponding place (with the corresponding
     workspace and channel) in cloud firestore.
     ASSUMPTION: pairedUsers length is always 2
@@ -103,7 +104,7 @@ exports.storeNewPairing = async function storeNewPairing(workspace, dmThreadID, 
     let usersRef = db.collection('workspaces').doc(workspace)
                            .collection('activeChannels').doc(channelID)
                            .collection('pairedUsers');
-
+    
     usersRef.doc(pairedUsers[0]).set({
         dmThreadID: dmThreadID,
         partnerID: pairedUsers[1],
@@ -151,7 +152,7 @@ exports.deletePairings = async function deletePairings(workspaceId, channelId){
         This function will store a newly designated pairing channel under the 'activeChannels' collection.
         In addition, it will delete the currently designated pairing channel and all data associated with it.
         We do this to enforce one pairing channel per workspace (for now).
-    Input:
+    Input: 
         workspaceID - workspace id
         channelID - channel id of the new channel designated as the pairing channel
 */
@@ -163,7 +164,7 @@ exports.storeNewPairingChannel = async function storeNewPairingChannel(workspace
 
     if (currChannel === undefined) {
         db.collection('workspaces').doc(workspaceID).set({}, {merge: true});
-        db.collection("workspaces").doc(workspaceID).collection('activeChannels').doc(newChannel).set({}, {merge: true});
+        db.collection("workspaces").doc(workspaceID).collection('activeChannels').doc(newChannel).set({}, {merge: true}); 
     }
     else {
         // To avoid the "ghost document" problem on the workspace
@@ -178,7 +179,7 @@ exports.storeNewPairingChannel = async function storeNewPairingChannel(workspace
 /*
     Description:
         Recursively deletes a specified collection from the db.
-
+    
     Input:
         collectionPath - path to get to the collection you want to delete.
         batchSize - the max # of documents you want to delete within that collection, I think?
@@ -191,7 +192,7 @@ function deleteCollection(collectionPath, batchSize) {
       deleteQueryBatch(query, resolve, reject);
     });
   }
-
+  
 /*
     Description:
         Helper function for deleteCollection
@@ -203,14 +204,14 @@ function deleteQueryBatch(query, resolve, reject) {
         if (snapshot.size === 0) {
             return 0;
         }
-
+  
         // Delete documents in a batch
         let batch = db.batch();
         snapshot.docs.forEach((doc) => {
           batch.delete(doc.ref);
           //console.log(doc.ref);
         });
-
+  
         // eslint-disable-next-line promise/no-nesting
         return batch.commit().then(() => {
           return snapshot.size;
@@ -220,7 +221,7 @@ function deleteQueryBatch(query, resolve, reject) {
           resolve();
           return;
         }
-
+  
         // Recurse on the next process tick, to avoid
         // exploding the stack.
         process.nextTick(() => {
@@ -231,11 +232,11 @@ function deleteQueryBatch(query, resolve, reject) {
       })
       .catch(reject);
 }
-
+ 
 /*
     Description:
         This function will retrieve the single pairing channel (id) corresponding to a workspace
-
+    
     Input:
         workspaceID: workspace id you're trying to get the pairing channel for.
 */
@@ -247,13 +248,13 @@ exports.getPairingChannel = async function getPairingChannel(workspaceID) {
     return allChannels[0];
 };
 
-/*
+/* 
     Description:
         This function gets called when a user picks an exercise for their pair's warmup or cooldown activity.
         The activity task prompt gets stored in the user's partner's warmup or cooldown task field.
         This function needs to determine the given user's partner as a part of the functionality which can
-        be found in the entry for that user in teammatePairings collection.
-    Input:
+        be found in the entry for that user in teammatePairings collection. 
+    Input: 
         workspaceID - workspace id
         userID - user id of user who selected this task for their partner
         isWarmup - (boolean) true if warmup, false if cooldown
@@ -272,9 +273,10 @@ exports.storeTypeOfExercise = async function storeTypeOfExercise(workspaceID, us
         setResult = await partnerRef.set({'cooldownTask': exercisePrompt}, {merge: true});
     }
 
-    console.log(workspaceID + "   " + userID);
-    firestoreFuncs.setPoints(workspaceID, userID);
-    //firestoreFuncs.getRankings(workspaceID); //testing the rankings function
+    // console.log(workspaceID + "   " + userID);
+    // update user's points
+    updatePoints(workspaceID, userID);
+	
     return setResult;
 }
 
@@ -294,7 +296,7 @@ exports.getExercisePrompt = async function getExercisePrompt(workspaceID, userID
     let channelID = await this.getPairingChannel(workspaceID);
     let userRef = db.collection("workspaces").doc(workspaceID).collection("activeChannels")
                     .doc(channelID).collection('pairedUsers').doc(userID);
-
+    
     return userRef.get()
         .then(doc => {
             if (!doc.exists) {
@@ -319,19 +321,19 @@ exports.getExercisePrompt = async function getExercisePrompt(workspaceID, userID
 /*
     Description:
         Given a user within a pairing channel, return its partner's userID.
-
+    
     Input:
         workspaceID - workspace id
         channelID - channel id over channel from which pairing was created
         userID - user id of user who you want to find their respective partner
-
+    
     Returns:
         partner's userID, or undefined if error or cannot find the user passed in
 */
 exports.getPartner = function getPartner(workspaceID, channelID, userID) {
     let userRef = db.collection("workspaces").doc(workspaceID).collection("activeChannels")
                     .doc(channelID).collection('pairedUsers').doc(userID);
-
+    
     return userRef.get()
         .then(doc => {
             if (!doc.exists) {
@@ -352,10 +354,10 @@ exports.getPartner = function getPartner(workspaceID, channelID, userID) {
     Description:
         Given a workspace and pairing channel id, return a list of objects, where
         each object contains the paired users, and the DM thread id they are paired within.
-
-    Input:
+    
+    Input: 
         workspaceID - workspace id
-
+    
     Return:
         If u1 is paired with u2 (in dm thread 'd1'), and u3 paired with u4 (in dm thread 'd2'),
         this function will return:
@@ -365,7 +367,7 @@ exports.getPairedUsers = async function getPairedUsers(workspaceID) {
     let channelID = await this.getPairingChannel(workspaceID);
     let userRef = db.collection("workspaces").doc(workspaceID).collection("activeChannels")
                     .doc(channelID).collection('pairedUsers');
-
+    
     return userRef.get().then((querySnapshot) => {
         let partnerIDs = [];
         let pairings = [];
@@ -379,12 +381,12 @@ exports.getPairedUsers = async function getPairedUsers(workspaceID) {
         return pairings;
     });
 };
-
+ 
 /*
     Description:
         Sets the warmup time (when they will receive their warmup task) for
         a particular user in the worskpace.
-
+    
     Inputs:
         workspaceID - workspace id of where time is getting set
         userID - user id for which the time/day is getting set
@@ -408,7 +410,7 @@ exports.setWarmupTime = function setWarmupTime(workspaceID, userID, time, day) {
     Inputs:
         workspaceID - workspace id of where time is getting retrieved
         userID - user id for which the time/day is getting retrieved
-        day - the day of the week this time is getting retrieved for
+        day - the day of the week this time is getting retrieved for 
               for ex: 'monday', 'tuesday', 'wednesday', etc.
 */
 exports.getWarmupTime = function getWarmupTime(workspaceID, userID, day) {
@@ -434,7 +436,7 @@ exports.getWarmupTime = function getWarmupTime(workspaceID, userID, day) {
     Description:
         Sets the cooldown time (when they will receive their cooldown task) for
         a particular user in the worskpace.
-
+    
     Inputs:
         workspaceID - workspace id of where time is getting set
         userID - user id for which the time/day is getting set
@@ -458,7 +460,7 @@ exports.setCooldownTime = function setWarmupTime(workspaceID, userID, time, day)
     Inputs:
         workspaceID - workspace id of where time is getting retrieved
         userID - user id for which the time/day is getting retrieved
-        day - the day of the week this time is getting retrieved for
+        day - the day of the week this time is getting retrieved for 
               for ex: 'monday', 'tuesday', 'wednesday', etc.
 */
 exports.getCooldownTime = function getWarmupTime(workspaceID, userID, day) {
@@ -484,7 +486,7 @@ exports.getCooldownTime = function getWarmupTime(workspaceID, userID, day) {
     Description:
         Gets the current workspace 'owner'
         Returns a promise that you have to 'await'
-
+    
     Input:
         workspaceID - workspace id that you want to get owner of
 */
@@ -510,7 +512,7 @@ exports.getOwner = function getOwner(workspaceID) {
 /*
     Description:
         Sets the owner associated with a given workspace
-
+    
     Inputs:
         workspaceID - workspace id of the workspace you want to set owner of
         userID - user id of the new owner
@@ -525,55 +527,8 @@ exports.setOwner = function updateOwner(workspaceID, userID) {
 
 /*
     Description:
-<<<<<<< HEAD
-        Gets timezone associated with the given workspace and the schedules of
-        everyone paired up within the designated pairing-channel in that workspace.
-        Returns a promise that you have to 'await'
-
-    Input:
-        workspaceID - workspace id that you want the associated timezone of
-*/
-exports.getTimeZone = function getTimezone(workspaceID) {
-    let workspaceDocRef = db.collection('workspaces').doc(workspaceID);
-
-    return workspaceDocRef.get()
-        .then(doc => {
-            if (!doc.exists) {
-                console.log('No such document!');
-                return undefined;
-            }
-            else {
-                return doc.data().timezone;
-            }
-        })
-        .catch(err => {
-            console.log('Error getting workspace document: ', err);
-            return undefined;
-        });
-};
-
-/*
-    Description:
-        Sets the timezone associated with a given workspace
-
-    Inputs:
-        workspaceID - workspace id of the workspace you want to set timezone for
-        timeZone - new timezone you want to set, in abbreviated format, ex: "PST"
-*/
-exports.setTimeZone = function updateTimeZone(workspaceID, timeZone) {
-    let workspaceDocRef = db.collection('workspaces').doc(workspaceID);
-
-    workspaceDocRef.set({
-        timezone: timeZone
-    }, {merge: true});
-};
-
-/*
-    Description:
-=======
->>>>>>> 5b4e6bd460ef8aadcc1827ba603844ab2c0b2be3
         Retrieves all workspace ids
-    Returns:
+    Returns: 
         list of workspace ids, for ex: ['T123452324', 'T62345234', 'T6762342342']
 */
 exports.getAllWorkspaces = async function getAllWorkspaces() {
@@ -586,11 +541,11 @@ exports.getAllWorkspaces = async function getAllWorkspaces() {
 /*
     Description:
         Gets all pairing data associated with a particular user
-
+    
     Inputs:
         workspaceID - the workspace the user you're querying about is in
         userID - the user id of the user you want the pairing data for
-
+    
     Returns:
         Returns a Promise that resolves into an object with the following keys:
         (obj) - {
@@ -621,7 +576,7 @@ exports.getUserPairingData = async function getUserData(workspaceID, userID) {
 }
 
 /*
-    setPoints(workspaceID, userID)
+    updatePoints(workspaceID, userID)
 
     Increments a user's weeklyPoints and monthlyPoints by 1.
     Called when a user sends either a warmup or cooldown to their partner.
@@ -629,7 +584,7 @@ exports.getUserPairingData = async function getUserData(workspaceID, userID) {
         workspaceID - current workspace ID
         userID      - ID of user whose points will be incremented
 */
-exports.setPoints = async function setPoints(workspaceID, userID) {
+exports.updatePoints = async function updatePoints(workspaceID, userID) {
     let userDocRef = db.collection('workspaces')
                     .doc(workspaceID)
                     .collection('users')

--- a/functions/firestore.js
+++ b/functions/firestore.js
@@ -7,9 +7,9 @@ const firestoreFuncs = require('./firestore');
 
 // console.log(typeof(process.env.FUNCTIONS_EMULATOR));
 if(process.env.FUNCTIONS_EMULATOR === "true"){
-
+    
     var serviceAccount = require('./serviceAccountKey.json');
-
+    
     admin.initializeApp({
         credential: admin.credential.cert(serviceAccount),
         databaseURL: "https://altitest-5f53d.firebaseio.com"
@@ -22,75 +22,76 @@ else{
 let db = admin.firestore();
 
 
-/*
-    storeAPIPair(team_id, api_key):
+/* 
+    storeAPIPair(team_id, api_key): 
 
-    Stores the API keys from the database by team_id.
+    Stores the API keys from the database by team_id. 
 
-    @@PARAMS
-    team_id: same thing as workspace id
+    @@PARAMS 
+    team_id: same thing as workspace id 
 
-    store the API-tokens/id's in the format:
-        {
+    store the API-tokens/id's in the format: 
+        { 
             botToken: "xxxxxxxxxxxxx",
             botId: "Bxxxxxxxxx",
             botUserId: "Uxxxxxxxxx"
         })
  */
-exports.storeAPIPair = (team_id, api_key) => {
+exports.storeAPIPair = (team_id, api_key) => { 
 
     let setValue = {
         botToken: api_key.botToken,
         botId: api_key.botId,
         botUserId: api_key.botUserId
-    };
+    }; 
 
     console.log("Team ID: " + team_id);
-    console.log("API Keys: Copy/Paste this" + JSON.stringify(setValue, null, 1));
+    console.log("API Keys: Copy/Paste this" + JSON.stringify(setValue, null, 1)); 
     db.collection('api_keys').doc(team_id).set(setValue);
 };
 
-/*
+/* 
     getAPIPair(team_id):
 
-    Gets the API keys from the database by team_id.
+    Gets the API keys from the database by team_id. 
 
-    @@PARAMS
-    team_id: same thing as workspace id
+    @@PARAMS 
+    team_id: same thing as workspace id 
 
-    return the API-tokens/id's in the format:
-        {
+    return the API-tokens/id's in the format: 
+        { 
             botToken: "xxxxxxxxxxxxx",
             botId: "Bxxxxxxxxx",
             botUserId: "Uxxxxxxxxx"
         })
  */
-exports.getAPIPair = (team_id) => {
+exports.getAPIPair = (team_id) => { 
         return db.collection('api_keys').doc(team_id).get().then((doc) => {
-            if (!(doc && doc.exists)) {
+            if (!(doc && doc.exists)) {	
 
                 //verbose debug message
-
+                
                 if(process.env.FUNCTIONS_EMULATOR === "true") {
-                    console.log(" Your API_Key is not in the firestore db. " +
+                    console.log(" Your API_Key is not in the firestore db. " + 
                     "\nRemember that data does not save after restart."+
                     "\n You may have to reinstall your app again if you are using the emulator.");
 
-                } else {
-                    console.log("Your API_Key is not in the firestore db. ");
+                } else { 
+                    console.log("Your API_Key is not in the firestore db. "); 
                 }
-                return null;
+                return null;	
             }
-
-            //returns the fetched value here
+            
+            //returns the fetched value here 
             return doc.data();
-        }).catch(() => {
+        }).catch(() => {	
             //return null if there was an error in fetching the data
             return null;
         });
 };
 
-/*
+
+/* 
     Stores the new pairings (DM thread ids + partnerIDs) in the corresponding place (with the corresponding
     workspace and channel) in cloud firestore.
     ASSUMPTION: pairedUsers length is always 2
@@ -104,7 +105,7 @@ exports.storeNewPairing = async function storeNewPairing(workspace, dmThreadID, 
     let usersRef = db.collection('workspaces').doc(workspace)
                            .collection('activeChannels').doc(channelID)
                            .collection('pairedUsers');
-
+    
     usersRef.doc(pairedUsers[0]).set({
         dmThreadID: dmThreadID,
         partnerID: pairedUsers[1],
@@ -152,7 +153,7 @@ exports.deletePairings = async function deletePairings(workspaceId, channelId){
         This function will store a newly designated pairing channel under the 'activeChannels' collection.
         In addition, it will delete the currently designated pairing channel and all data associated with it.
         We do this to enforce one pairing channel per workspace (for now).
-    Input:
+    Input: 
         workspaceID - workspace id
         channelID - channel id of the new channel designated as the pairing channel
 */
@@ -164,7 +165,7 @@ exports.storeNewPairingChannel = async function storeNewPairingChannel(workspace
 
     if (currChannel === undefined) {
         db.collection('workspaces').doc(workspaceID).set({}, {merge: true});
-        db.collection("workspaces").doc(workspaceID).collection('activeChannels').doc(newChannel).set({}, {merge: true});
+        db.collection("workspaces").doc(workspaceID).collection('activeChannels').doc(newChannel).set({}, {merge: true}); 
     }
     else {
         // To avoid the "ghost document" problem on the workspace
@@ -179,7 +180,7 @@ exports.storeNewPairingChannel = async function storeNewPairingChannel(workspace
 /*
     Description:
         Recursively deletes a specified collection from the db.
-
+    
     Input:
         collectionPath - path to get to the collection you want to delete.
         batchSize - the max # of documents you want to delete within that collection, I think?
@@ -192,7 +193,7 @@ function deleteCollection(collectionPath, batchSize) {
       deleteQueryBatch(query, resolve, reject);
     });
   }
-
+  
 /*
     Description:
         Helper function for deleteCollection
@@ -204,14 +205,14 @@ function deleteQueryBatch(query, resolve, reject) {
         if (snapshot.size === 0) {
             return 0;
         }
-
+  
         // Delete documents in a batch
         let batch = db.batch();
         snapshot.docs.forEach((doc) => {
           batch.delete(doc.ref);
           //console.log(doc.ref);
         });
-
+  
         // eslint-disable-next-line promise/no-nesting
         return batch.commit().then(() => {
           return snapshot.size;
@@ -221,7 +222,7 @@ function deleteQueryBatch(query, resolve, reject) {
           resolve();
           return;
         }
-
+  
         // Recurse on the next process tick, to avoid
         // exploding the stack.
         process.nextTick(() => {
@@ -232,11 +233,11 @@ function deleteQueryBatch(query, resolve, reject) {
       })
       .catch(reject);
 }
-
+ 
 /*
     Description:
         This function will retrieve the single pairing channel (id) corresponding to a workspace
-
+    
     Input:
         workspaceID: workspace id you're trying to get the pairing channel for.
 */
@@ -248,13 +249,13 @@ exports.getPairingChannel = async function getPairingChannel(workspaceID) {
     return allChannels[0];
 };
 
-/*
+/* 
     Description:
         This function gets called when a user picks an exercise for their pair's warmup or cooldown activity.
         The activity task prompt gets stored in the user's partner's warmup or cooldown task field.
         This function needs to determine the given user's partner as a part of the functionality which can
-        be found in the entry for that user in teammatePairings collection.
-    Input:
+        be found in the entry for that user in teammatePairings collection. 
+    Input: 
         workspaceID - workspace id
         userID - user id of user who selected this task for their partner
         isWarmup - (boolean) true if warmup, false if cooldown
@@ -272,12 +273,11 @@ exports.storeTypeOfExercise = async function storeTypeOfExercise(workspaceID, us
     else {
         setResult = await partnerRef.set({'cooldownTask': exercisePrompt}, {merge: true});
     }
-
     //console.log(workspaceID + "   " + userID);
-
     // update user's points
     firestoreFuncs.updatePoints(workspaceID, userID);
     return setResult;
+	
 }
 
 /*
@@ -296,7 +296,7 @@ exports.getExercisePrompt = async function getExercisePrompt(workspaceID, userID
     let channelID = await this.getPairingChannel(workspaceID);
     let userRef = db.collection("workspaces").doc(workspaceID).collection("activeChannels")
                     .doc(channelID).collection('pairedUsers').doc(userID);
-
+    
     return userRef.get()
         .then(doc => {
             if (!doc.exists) {
@@ -321,19 +321,19 @@ exports.getExercisePrompt = async function getExercisePrompt(workspaceID, userID
 /*
     Description:
         Given a user within a pairing channel, return its partner's userID.
-
+    
     Input:
         workspaceID - workspace id
         channelID - channel id over channel from which pairing was created
         userID - user id of user who you want to find their respective partner
-
+    
     Returns:
         partner's userID, or undefined if error or cannot find the user passed in
 */
 exports.getPartner = function getPartner(workspaceID, channelID, userID) {
     let userRef = db.collection("workspaces").doc(workspaceID).collection("activeChannels")
                     .doc(channelID).collection('pairedUsers').doc(userID);
-
+    
     return userRef.get()
         .then(doc => {
             if (!doc.exists) {
@@ -354,10 +354,10 @@ exports.getPartner = function getPartner(workspaceID, channelID, userID) {
     Description:
         Given a workspace and pairing channel id, return a list of objects, where
         each object contains the paired users, and the DM thread id they are paired within.
-
-    Input:
+    
+    Input: 
         workspaceID - workspace id
-
+    
     Return:
         If u1 is paired with u2 (in dm thread 'd1'), and u3 paired with u4 (in dm thread 'd2'),
         this function will return:
@@ -367,7 +367,7 @@ exports.getPairedUsers = async function getPairedUsers(workspaceID) {
     let channelID = await this.getPairingChannel(workspaceID);
     let userRef = db.collection("workspaces").doc(workspaceID).collection("activeChannels")
                     .doc(channelID).collection('pairedUsers');
-
+    
     return userRef.get().then((querySnapshot) => {
         let partnerIDs = [];
         let pairings = [];
@@ -381,12 +381,12 @@ exports.getPairedUsers = async function getPairedUsers(workspaceID) {
         return pairings;
     });
 };
-
+ 
 /*
     Description:
         Sets the warmup time (when they will receive their warmup task) for
         a particular user in the worskpace.
-
+    
     Inputs:
         workspaceID - workspace id of where time is getting set
         userID - user id for which the time/day is getting set
@@ -410,7 +410,7 @@ exports.setWarmupTime = function setWarmupTime(workspaceID, userID, time, day) {
     Inputs:
         workspaceID - workspace id of where time is getting retrieved
         userID - user id for which the time/day is getting retrieved
-        day - the day of the week this time is getting retrieved for
+        day - the day of the week this time is getting retrieved for 
               for ex: 'monday', 'tuesday', 'wednesday', etc.
 */
 exports.getWarmupTime = function getWarmupTime(workspaceID, userID, day) {
@@ -436,7 +436,7 @@ exports.getWarmupTime = function getWarmupTime(workspaceID, userID, day) {
     Description:
         Sets the cooldown time (when they will receive their cooldown task) for
         a particular user in the worskpace.
-
+    
     Inputs:
         workspaceID - workspace id of where time is getting set
         userID - user id for which the time/day is getting set
@@ -460,7 +460,7 @@ exports.setCooldownTime = function setWarmupTime(workspaceID, userID, time, day)
     Inputs:
         workspaceID - workspace id of where time is getting retrieved
         userID - user id for which the time/day is getting retrieved
-        day - the day of the week this time is getting retrieved for
+        day - the day of the week this time is getting retrieved for 
               for ex: 'monday', 'tuesday', 'wednesday', etc.
 */
 exports.getCooldownTime = function getWarmupTime(workspaceID, userID, day) {
@@ -486,7 +486,7 @@ exports.getCooldownTime = function getWarmupTime(workspaceID, userID, day) {
     Description:
         Gets the current workspace 'owner'
         Returns a promise that you have to 'await'
-
+    
     Input:
         workspaceID - workspace id that you want to get owner of
 */
@@ -512,7 +512,7 @@ exports.getOwner = function getOwner(workspaceID) {
 /*
     Description:
         Sets the owner associated with a given workspace
-
+    
     Inputs:
         workspaceID - workspace id of the workspace you want to set owner of
         userID - user id of the new owner
@@ -528,7 +528,7 @@ exports.setOwner = function updateOwner(workspaceID, userID) {
 /*
     Description:
         Retrieves all workspace ids
-    Returns:
+    Returns: 
         list of workspace ids, for ex: ['T123452324', 'T62345234', 'T6762342342']
 */
 exports.getAllWorkspaces = async function getAllWorkspaces() {
@@ -541,11 +541,11 @@ exports.getAllWorkspaces = async function getAllWorkspaces() {
 /*
     Description:
         Gets all pairing data associated with a particular user
-
+    
     Inputs:
         workspaceID - the workspace the user you're querying about is in
         userID - the user id of the user you want the pairing data for
-
+    
     Returns:
         Returns a Promise that resolves into an object with the following keys:
         (obj) - {

--- a/functions/firestore.js
+++ b/functions/firestore.js
@@ -7,9 +7,9 @@ const firestoreFuncs = require('./firestore');
 
 // console.log(typeof(process.env.FUNCTIONS_EMULATOR));
 if(process.env.FUNCTIONS_EMULATOR === "true"){
-    
+
     var serviceAccount = require('./serviceAccountKey.json');
-    
+
     admin.initializeApp({
         credential: admin.credential.cert(serviceAccount),
         databaseURL: "https://altitest-5f53d.firebaseio.com"
@@ -22,76 +22,75 @@ else{
 let db = admin.firestore();
 
 
-/* 
-    storeAPIPair(team_id, api_key): 
+/*
+    storeAPIPair(team_id, api_key):
 
-    Stores the API keys from the database by team_id. 
+    Stores the API keys from the database by team_id.
 
-    @@PARAMS 
-    team_id: same thing as workspace id 
+    @@PARAMS
+    team_id: same thing as workspace id
 
-    store the API-tokens/id's in the format: 
-        { 
+    store the API-tokens/id's in the format:
+        {
             botToken: "xxxxxxxxxxxxx",
             botId: "Bxxxxxxxxx",
             botUserId: "Uxxxxxxxxx"
         })
  */
-exports.storeAPIPair = (team_id, api_key) => { 
+exports.storeAPIPair = (team_id, api_key) => {
 
     let setValue = {
         botToken: api_key.botToken,
         botId: api_key.botId,
         botUserId: api_key.botUserId
-    }; 
+    };
 
     console.log("Team ID: " + team_id);
-    console.log("API Keys: Copy/Paste this" + JSON.stringify(setValue, null, 1)); 
+    console.log("API Keys: Copy/Paste this" + JSON.stringify(setValue, null, 1));
     db.collection('api_keys').doc(team_id).set(setValue);
 };
 
-/* 
+/*
     getAPIPair(team_id):
 
-    Gets the API keys from the database by team_id. 
+    Gets the API keys from the database by team_id.
 
-    @@PARAMS 
-    team_id: same thing as workspace id 
+    @@PARAMS
+    team_id: same thing as workspace id
 
-    return the API-tokens/id's in the format: 
-        { 
+    return the API-tokens/id's in the format:
+        {
             botToken: "xxxxxxxxxxxxx",
             botId: "Bxxxxxxxxx",
             botUserId: "Uxxxxxxxxx"
         })
  */
-exports.getAPIPair = (team_id) => { 
+exports.getAPIPair = (team_id) => {
         return db.collection('api_keys').doc(team_id).get().then((doc) => {
-            if (!(doc && doc.exists)) {	
+            if (!(doc && doc.exists)) {
 
                 //verbose debug message
-                
+
                 if(process.env.FUNCTIONS_EMULATOR === "true") {
-                    console.log(" Your API_Key is not in the firestore db. " + 
+                    console.log(" Your API_Key is not in the firestore db. " +
                     "\nRemember that data does not save after restart."+
                     "\n You may have to reinstall your app again if you are using the emulator.");
 
-                } else { 
-                    console.log("Your API_Key is not in the firestore db. "); 
+                } else {
+                    console.log("Your API_Key is not in the firestore db. ");
                 }
-                return null;	
+                return null;
             }
-            
-            //returns the fetched value here 
+
+            //returns the fetched value here
             return doc.data();
-        }).catch(() => {	
+        }).catch(() => {
             //return null if there was an error in fetching the data
             return null;
         });
 };
 
-
-/* 
+/*
     Stores the new pairings (DM thread ids + partnerIDs) in the corresponding place (with the corresponding
     workspace and channel) in cloud firestore.
     ASSUMPTION: pairedUsers length is always 2
@@ -105,7 +104,7 @@ exports.storeNewPairing = async function storeNewPairing(workspace, dmThreadID, 
     let usersRef = db.collection('workspaces').doc(workspace)
                            .collection('activeChannels').doc(channelID)
                            .collection('pairedUsers');
-    
+
     usersRef.doc(pairedUsers[0]).set({
         dmThreadID: dmThreadID,
         partnerID: pairedUsers[1],
@@ -153,7 +152,7 @@ exports.deletePairings = async function deletePairings(workspaceId, channelId){
         This function will store a newly designated pairing channel under the 'activeChannels' collection.
         In addition, it will delete the currently designated pairing channel and all data associated with it.
         We do this to enforce one pairing channel per workspace (for now).
-    Input: 
+    Input:
         workspaceID - workspace id
         channelID - channel id of the new channel designated as the pairing channel
 */
@@ -165,7 +164,7 @@ exports.storeNewPairingChannel = async function storeNewPairingChannel(workspace
 
     if (currChannel === undefined) {
         db.collection('workspaces').doc(workspaceID).set({}, {merge: true});
-        db.collection("workspaces").doc(workspaceID).collection('activeChannels').doc(newChannel).set({}, {merge: true}); 
+        db.collection("workspaces").doc(workspaceID).collection('activeChannels').doc(newChannel).set({}, {merge: true});
     }
     else {
         // To avoid the "ghost document" problem on the workspace
@@ -180,7 +179,7 @@ exports.storeNewPairingChannel = async function storeNewPairingChannel(workspace
 /*
     Description:
         Recursively deletes a specified collection from the db.
-    
+
     Input:
         collectionPath - path to get to the collection you want to delete.
         batchSize - the max # of documents you want to delete within that collection, I think?
@@ -193,7 +192,7 @@ function deleteCollection(collectionPath, batchSize) {
       deleteQueryBatch(query, resolve, reject);
     });
   }
-  
+
 /*
     Description:
         Helper function for deleteCollection
@@ -205,14 +204,14 @@ function deleteQueryBatch(query, resolve, reject) {
         if (snapshot.size === 0) {
             return 0;
         }
-  
+
         // Delete documents in a batch
         let batch = db.batch();
         snapshot.docs.forEach((doc) => {
           batch.delete(doc.ref);
           //console.log(doc.ref);
         });
-  
+
         // eslint-disable-next-line promise/no-nesting
         return batch.commit().then(() => {
           return snapshot.size;
@@ -222,7 +221,7 @@ function deleteQueryBatch(query, resolve, reject) {
           resolve();
           return;
         }
-  
+
         // Recurse on the next process tick, to avoid
         // exploding the stack.
         process.nextTick(() => {
@@ -233,11 +232,11 @@ function deleteQueryBatch(query, resolve, reject) {
       })
       .catch(reject);
 }
- 
+
 /*
     Description:
         This function will retrieve the single pairing channel (id) corresponding to a workspace
-    
+
     Input:
         workspaceID: workspace id you're trying to get the pairing channel for.
 */
@@ -249,13 +248,13 @@ exports.getPairingChannel = async function getPairingChannel(workspaceID) {
     return allChannels[0];
 };
 
-/* 
+/*
     Description:
         This function gets called when a user picks an exercise for their pair's warmup or cooldown activity.
         The activity task prompt gets stored in the user's partner's warmup or cooldown task field.
         This function needs to determine the given user's partner as a part of the functionality which can
-        be found in the entry for that user in teammatePairings collection. 
-    Input: 
+        be found in the entry for that user in teammatePairings collection.
+    Input:
         workspaceID - workspace id
         userID - user id of user who selected this task for their partner
         isWarmup - (boolean) true if warmup, false if cooldown
@@ -274,9 +273,10 @@ exports.storeTypeOfExercise = async function storeTypeOfExercise(workspaceID, us
         setResult = await partnerRef.set({'cooldownTask': exercisePrompt}, {merge: true});
     }
 
-    // console.log(workspaceID + "   " + userID);
+    //console.log(workspaceID + "   " + userID);
+
     // update user's points
-    firestoreFuncs.updatePoints(workspaceID, userID);	
+    firestoreFuncs.updatePoints(workspaceID, userID);
     return setResult;
 }
 
@@ -296,7 +296,7 @@ exports.getExercisePrompt = async function getExercisePrompt(workspaceID, userID
     let channelID = await this.getPairingChannel(workspaceID);
     let userRef = db.collection("workspaces").doc(workspaceID).collection("activeChannels")
                     .doc(channelID).collection('pairedUsers').doc(userID);
-    
+
     return userRef.get()
         .then(doc => {
             if (!doc.exists) {
@@ -321,19 +321,19 @@ exports.getExercisePrompt = async function getExercisePrompt(workspaceID, userID
 /*
     Description:
         Given a user within a pairing channel, return its partner's userID.
-    
+
     Input:
         workspaceID - workspace id
         channelID - channel id over channel from which pairing was created
         userID - user id of user who you want to find their respective partner
-    
+
     Returns:
         partner's userID, or undefined if error or cannot find the user passed in
 */
 exports.getPartner = function getPartner(workspaceID, channelID, userID) {
     let userRef = db.collection("workspaces").doc(workspaceID).collection("activeChannels")
                     .doc(channelID).collection('pairedUsers').doc(userID);
-    
+
     return userRef.get()
         .then(doc => {
             if (!doc.exists) {
@@ -354,10 +354,10 @@ exports.getPartner = function getPartner(workspaceID, channelID, userID) {
     Description:
         Given a workspace and pairing channel id, return a list of objects, where
         each object contains the paired users, and the DM thread id they are paired within.
-    
-    Input: 
+
+    Input:
         workspaceID - workspace id
-    
+
     Return:
         If u1 is paired with u2 (in dm thread 'd1'), and u3 paired with u4 (in dm thread 'd2'),
         this function will return:
@@ -367,7 +367,7 @@ exports.getPairedUsers = async function getPairedUsers(workspaceID) {
     let channelID = await this.getPairingChannel(workspaceID);
     let userRef = db.collection("workspaces").doc(workspaceID).collection("activeChannels")
                     .doc(channelID).collection('pairedUsers');
-    
+
     return userRef.get().then((querySnapshot) => {
         let partnerIDs = [];
         let pairings = [];
@@ -381,12 +381,12 @@ exports.getPairedUsers = async function getPairedUsers(workspaceID) {
         return pairings;
     });
 };
- 
+
 /*
     Description:
         Sets the warmup time (when they will receive their warmup task) for
         a particular user in the worskpace.
-    
+
     Inputs:
         workspaceID - workspace id of where time is getting set
         userID - user id for which the time/day is getting set
@@ -410,7 +410,7 @@ exports.setWarmupTime = function setWarmupTime(workspaceID, userID, time, day) {
     Inputs:
         workspaceID - workspace id of where time is getting retrieved
         userID - user id for which the time/day is getting retrieved
-        day - the day of the week this time is getting retrieved for 
+        day - the day of the week this time is getting retrieved for
               for ex: 'monday', 'tuesday', 'wednesday', etc.
 */
 exports.getWarmupTime = function getWarmupTime(workspaceID, userID, day) {
@@ -436,7 +436,7 @@ exports.getWarmupTime = function getWarmupTime(workspaceID, userID, day) {
     Description:
         Sets the cooldown time (when they will receive their cooldown task) for
         a particular user in the worskpace.
-    
+
     Inputs:
         workspaceID - workspace id of where time is getting set
         userID - user id for which the time/day is getting set
@@ -460,7 +460,7 @@ exports.setCooldownTime = function setWarmupTime(workspaceID, userID, time, day)
     Inputs:
         workspaceID - workspace id of where time is getting retrieved
         userID - user id for which the time/day is getting retrieved
-        day - the day of the week this time is getting retrieved for 
+        day - the day of the week this time is getting retrieved for
               for ex: 'monday', 'tuesday', 'wednesday', etc.
 */
 exports.getCooldownTime = function getWarmupTime(workspaceID, userID, day) {
@@ -486,7 +486,7 @@ exports.getCooldownTime = function getWarmupTime(workspaceID, userID, day) {
     Description:
         Gets the current workspace 'owner'
         Returns a promise that you have to 'await'
-    
+
     Input:
         workspaceID - workspace id that you want to get owner of
 */
@@ -512,7 +512,7 @@ exports.getOwner = function getOwner(workspaceID) {
 /*
     Description:
         Sets the owner associated with a given workspace
-    
+
     Inputs:
         workspaceID - workspace id of the workspace you want to set owner of
         userID - user id of the new owner
@@ -528,7 +528,7 @@ exports.setOwner = function updateOwner(workspaceID, userID) {
 /*
     Description:
         Retrieves all workspace ids
-    Returns: 
+    Returns:
         list of workspace ids, for ex: ['T123452324', 'T62345234', 'T6762342342']
 */
 exports.getAllWorkspaces = async function getAllWorkspaces() {
@@ -541,11 +541,11 @@ exports.getAllWorkspaces = async function getAllWorkspaces() {
 /*
     Description:
         Gets all pairing data associated with a particular user
-    
+
     Inputs:
         workspaceID - the workspace the user you're querying about is in
         userID - the user id of the user you want the pairing data for
-    
+
     Returns:
         Returns a Promise that resolves into an object with the following keys:
         (obj) - {

--- a/functions/firestore.js
+++ b/functions/firestore.js
@@ -1,6 +1,7 @@
 const functions = require('firebase-functions');
 const admin = require('firebase-admin');
 const request = require('request');
+const firestoreFuncs = require('./firestore');
 // const dotenv = require('dotenv');
 // dotenv.config();
 
@@ -275,8 +276,7 @@ exports.storeTypeOfExercise = async function storeTypeOfExercise(workspaceID, us
 
     // console.log(workspaceID + "   " + userID);
     // update user's points
-    updatePoints(workspaceID, userID);
-	
+    firestoreFuncs.updatePoints(workspaceID, userID);	
     return setResult;
 }
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -23,7 +23,7 @@ const app = new App({
     authorize: authorizeFunction,
 });
 
-//arrow function for simplicity
+//arrow function for simplicity 
 exports.getBolt = () => app;
 
 
@@ -43,7 +43,8 @@ exports.scheduleDaily = pubsubScheduler.scheduleDaily;
 exports.scheduleResetWeeklyPoints = leaderboard.scheduleResetWeeklyPoints;
 exports.scheduleResetMonthlyPoints = leaderboard.scheduleResetMonthlyPoints;
 
-//Test Ruixian
+
+//Test Ruixian 
 exports.test1 = pubsubScheduler.test1;
 //
 
@@ -57,7 +58,7 @@ app.error(console.log);
 //     say(`Trying to schedule a warmup`);
 //     //let hour = parseInt(command.text.split(" ")[0])
 //     //let minute = parseInt(command.text.split(" ")[1])
-//     //schedule.warmup(app, bot_token, hour , minute);
+//     //schedule.warmup(app, bot_token, hour , minute); 
 // });
 
 
@@ -82,15 +83,15 @@ app.message(async ({ message, context }) => {
 exports.slack = functions.https.onRequest(expressReceiver.app);
 
 
-//export this to separate file
-exports.oauth = oauthEndpoint.oAuthFunction;
+//export this to separate file 
+exports.oauth = oauthEndpoint.oAuthFunction; 
 
-app.command('/firestore', async ({ command, ack, say}) => {
-    // Acknowledge command request
-    ack();
+app.command('/firestore', async ({ command, ack, say}) => {	
+    // Acknowledge command request	 
+    ack();	
     firestoreFuncs.firestoreTest();
-    say(`Trying to firebase`);
-});
+    say(`Trying to firebase`);	
+}); 
 
 
 
@@ -123,9 +124,9 @@ app.action('generic_button', async ({ action, ack, context }) => {
 });
 /*
 request_custom_send Action Listener
-Descr: Listens for a slack provided action id matching
+Descr: Listens for a slack provided action id matching 
 'request_custom_send' and opens a model for sending a custom message
-in the user's from where the action originated from window with a
+in the user's from where the action originated from window with a 
 model for sending a custom message
 return:
 na
@@ -133,12 +134,12 @@ na
 app.action('request_custom_send', async ({ ack, body, context }) => {
    warmupMessage.requestCustomSend(ack,body,context);
  });
-
+ 
 /*
 custom_msg_view view Listener
-Descr: Listens for a slack provided view id matching
+Descr: Listens for a slack provided view id matching 
 'custom_msg_view' and stores a custom message submitted in this view
-within firebase.
+within firebase. 
 return:
 na
 */
@@ -158,7 +159,7 @@ app.command('/setupcooldown', async ({ command, ack, say, context }) => {
 app.action('cooldown_video_select', async ({ ack, body, context }) => {
    warmupMessage.cooldownVideoSelect(ack,body,context);
  });
-
+ 
 app.action('cooldown_article_select', async ({ ack, body, context }) => {
    warmupMessage.cooldownArticleSelect(ack,body,context);
  });
@@ -166,19 +167,19 @@ app.action('cooldown_article_select', async ({ ack, body, context }) => {
 app.action('cooldown_retro_select', async ({ ack, body, context }) => {
    warmupMessage.cooldownRetroSelect(ack,body,context);
  });
-
+ 
 app.action('cooldown_custom_select', async ({ ack, body, context }) => {
    warmupMessage.requestCustomSendCooldown(ack,body,context);
  });
-
+ 
 app.view('custom_msg_view_cooldown', async ({ ack, body, view, context }) => {
 	warmupMessage.customMsgView(ack, body, view, context,false);
 });
-
+ 
 app.action('warmup_coding_select', async ({ ack, body, context }) => {
    warmupMessage.warmupCodingSelect(ack,body,context);
  });
-
+ 
  app.action('warmup_article_select', async ({ ack, body, context }) => {
    warmupMessage.warmupArticleSelect(ack,body,context);
  });
@@ -190,25 +191,25 @@ app.action('warmup_puzzle_select', async ({ ack, body, context }) => {
 app.action('warmup_quote_select', async ({ ack, body, context }) => {
    warmupMessage.warmupQuoteSelect(ack,body,context);
  });
-
+ 
  app.action('warmup_quote_select', async ({ ack, body, context }) => {
    warmupMessage.warmupQuoteSelect(ack,body,context);
  });
 
 
 
-
+ 
  app.view('generic_close', async ({ ack, body, context }) => {
     ack({
 	  //clear the modal off the users screen
 	 "response_action": "clear"
   });
  });
-
+  
  app.action('generic_ack', async ({ ack, body, context }) => {
     ack();
  });
-
+ 
 exports.testFirestore = functions.https.onRequest(async (req, res) => {
     console.log(await  firestoreFuncs.getExercisePrompt('T011H6FAPV4', 'U011C8CCYDV', true));
 });

--- a/functions/index.js
+++ b/functions/index.js
@@ -23,7 +23,7 @@ const app = new App({
     authorize: authorizeFunction,
 });
 
-//arrow function for simplicity 
+//arrow function for simplicity
 exports.getBolt = () => app;
 
 
@@ -36,12 +36,14 @@ const onBoard = require('./onBoard');
 const appHome = require('./appHome');
 const appHomeSchedule = require('./appHomeSchedule');
 const createNewChannel = require('./createNewChannel');
+const leaderboard = require('./leaderboard');
 exports.scheduledPairUp = pubsubScheduler.scheduledPairUp;
 exports.scheduleWarmup = pubsubScheduler.scheduleWarmup;
 exports.scheduleDaily = pubsubScheduler.scheduleDaily;
+exports.scheduleResetWeeklyPoints = leaderboard.scheduleResetWeeklyPoints;
+exports.scheduleResetMonthlyPoints = leaderboard.scheduleResetMonthlyPoints;
 
-
-//Test Ruixian 
+//Test Ruixian
 exports.test1 = pubsubScheduler.test1;
 //
 
@@ -55,7 +57,7 @@ app.error(console.log);
 //     say(`Trying to schedule a warmup`);
 //     //let hour = parseInt(command.text.split(" ")[0])
 //     //let minute = parseInt(command.text.split(" ")[1])
-//     //schedule.warmup(app, bot_token, hour , minute); 
+//     //schedule.warmup(app, bot_token, hour , minute);
 // });
 
 
@@ -80,15 +82,15 @@ app.message(async ({ message, context }) => {
 exports.slack = functions.https.onRequest(expressReceiver.app);
 
 
-//export this to separate file 
-exports.oauth = oauthEndpoint.oAuthFunction; 
+//export this to separate file
+exports.oauth = oauthEndpoint.oAuthFunction;
 
-app.command('/firestore', async ({ command, ack, say}) => {	
-    // Acknowledge command request	 
-    ack();	
+app.command('/firestore', async ({ command, ack, say}) => {
+    // Acknowledge command request
+    ack();
     firestoreFuncs.firestoreTest();
-    say(`Trying to firebase`);	
-}); 
+    say(`Trying to firebase`);
+});
 
 
 
@@ -121,9 +123,9 @@ app.action('generic_button', async ({ action, ack, context }) => {
 });
 /*
 request_custom_send Action Listener
-Descr: Listens for a slack provided action id matching 
+Descr: Listens for a slack provided action id matching
 'request_custom_send' and opens a model for sending a custom message
-in the user's from where the action originated from window with a 
+in the user's from where the action originated from window with a
 model for sending a custom message
 return:
 na
@@ -131,12 +133,12 @@ na
 app.action('request_custom_send', async ({ ack, body, context }) => {
    warmupMessage.requestCustomSend(ack,body,context);
  });
- 
+
 /*
 custom_msg_view view Listener
-Descr: Listens for a slack provided view id matching 
+Descr: Listens for a slack provided view id matching
 'custom_msg_view' and stores a custom message submitted in this view
-within firebase. 
+within firebase.
 return:
 na
 */
@@ -156,7 +158,7 @@ app.command('/setupcooldown', async ({ command, ack, say, context }) => {
 app.action('cooldown_video_select', async ({ ack, body, context }) => {
    warmupMessage.cooldownVideoSelect(ack,body,context);
  });
- 
+
 app.action('cooldown_article_select', async ({ ack, body, context }) => {
    warmupMessage.cooldownArticleSelect(ack,body,context);
  });
@@ -164,19 +166,19 @@ app.action('cooldown_article_select', async ({ ack, body, context }) => {
 app.action('cooldown_retro_select', async ({ ack, body, context }) => {
    warmupMessage.cooldownRetroSelect(ack,body,context);
  });
- 
+
 app.action('cooldown_custom_select', async ({ ack, body, context }) => {
    warmupMessage.requestCustomSendCooldown(ack,body,context);
  });
- 
+
 app.view('custom_msg_view_cooldown', async ({ ack, body, view, context }) => {
 	warmupMessage.customMsgView(ack, body, view, context,false);
 });
- 
+
 app.action('warmup_coding_select', async ({ ack, body, context }) => {
    warmupMessage.warmupCodingSelect(ack,body,context);
  });
- 
+
  app.action('warmup_article_select', async ({ ack, body, context }) => {
    warmupMessage.warmupArticleSelect(ack,body,context);
  });
@@ -188,25 +190,25 @@ app.action('warmup_puzzle_select', async ({ ack, body, context }) => {
 app.action('warmup_quote_select', async ({ ack, body, context }) => {
    warmupMessage.warmupQuoteSelect(ack,body,context);
  });
- 
+
  app.action('warmup_quote_select', async ({ ack, body, context }) => {
    warmupMessage.warmupQuoteSelect(ack,body,context);
  });
 
 
 
- 
+
  app.view('generic_close', async ({ ack, body, context }) => {
     ack({
 	  //clear the modal off the users screen
 	 "response_action": "clear"
   });
  });
-  
+
  app.action('generic_ack', async ({ ack, body, context }) => {
     ack();
  });
- 
+
 exports.testFirestore = functions.https.onRequest(async (req, res) => {
     console.log(await  firestoreFuncs.getExercisePrompt('T011H6FAPV4', 'U011C8CCYDV', true));
 });

--- a/functions/leaderboard.js
+++ b/functions/leaderboard.js
@@ -113,15 +113,15 @@ exports.getLeaderboards = async (app, token, workspaceID) => {
     const rankingsArr = await firestoreFuncs.getRankings(workspaceID);
 
     // get user real names (not IDs)
-    for (i = 0; i < rankingsArr.length; i++) {
-        var m = await app.client.users.info({
+    await Promise.all(rankingsArr.map(async (ranking) => {
+        const m = await app.client.users.info({
             token: token,
-            user: rankingsArr[i]['id']
+            user: ranking['id']
         });
-        if (rankingsArr[i]['id'] !== undefined) {
-            rankingsArr[i]['id'] = m.user.real_name;
+        if (ranking['id'] !== undefined) {
+            ranking['id'] = m.user.real_name;
         }
-    }
+    }));
 
     // get leaderboard strings
     const weeklyLeaderboard = getWeeklyLeaderboardStr(rankingsArr);

--- a/functions/leaderboard.js
+++ b/functions/leaderboard.js
@@ -7,10 +7,10 @@ const functions = require('firebase-functions');
     scheduleResetWeeklyPoints
 
     Resets all users' weeklyPoints to 0 
-    every Sunday at 11:59 PM Pacific Time.
+    every Monday at 12 AM Pacific Time.
 */
 exports.scheduleResetWeeklyPoints = functions.pubsub
-                                .schedule('every sunday 23:59')
+                                .schedule('every monday 00:00')
 	                            .timeZone('America/Los_Angeles')
 	                            .onRun(async (context) =>  {
     
@@ -39,11 +39,11 @@ exports.scheduleResetWeeklyPoints = functions.pubsub
 /*
     scheduleResetMonthlyPoints
 
-    Resets all users' monthlyPoints to 0 
-    at the end of every month at 11:59 PM Pacific Time.
+    Resets all users' monthlyPoints to 0 at the 
+    beginning of every month at 12 AM Pacific Time.
 */
 exports.scheduleResetMonthlyPoints = functions.pubsub
-                                .schedule('every sunday 23:59') // CHANGE THIS
+                                .schedule('first of month 00:00')
 	                            .timeZone('America/Los_Angeles')
 	                            .onRun(async (context) =>  {
     

--- a/functions/leaderboard.js
+++ b/functions/leaderboard.js
@@ -1,0 +1,304 @@
+const index = require('./index');
+const app = index.getBolt();
+const firestoreFuncs = require('./firestore');
+const functions = require('firebase-functions');
+
+/*
+    scheduleResetWeeklyPoints
+
+    Resets all users' weeklyPoints to 0 
+    every Sunday at 11:59 PM Pacific Time.
+*/
+exports.scheduleResetWeeklyPoints = functions.pubsub
+                                .schedule('every sunday 23:59')
+	                            .timeZone('America/Los_Angeles')
+	                            .onRun(async (context) =>  {
+    
+    // get bot token
+    token = context.botToken;
+
+    // get workspace info
+    const workspaceInfo = await app.client.team.info({
+        token: token
+    });
+
+    // get workspace id
+    const workspaceID = workspaceInfo.team.id;
+
+    // get list of user IDs in workspace
+    var userList = await getUsersInWorkSpace(app, token);
+
+    // reset everyone's weekly points
+    for (var userID of userList) {
+        firestoreFuncs.resetWeeklyPoints(workspaceID, userID);
+    }
+
+	return null;
+});
+
+/*
+    scheduleResetMonthlyPoints
+
+    Resets all users' monthlyPoints to 0 
+    at the end of every month at 11:59 PM Pacific Time.
+*/
+exports.scheduleResetMonthlyPoints = functions.pubsub
+                                .schedule('every sunday 23:59') // CHANGE THIS
+	                            .timeZone('America/Los_Angeles')
+	                            .onRun(async (context) =>  {
+    
+    // get bot token
+    token = context.botToken;
+
+    // get workspace info
+    const workspaceInfo = await app.client.team.info({
+        token: token
+    });
+
+    // get workspace id
+    const workspaceID = workspaceInfo.team.id;
+
+    // get list of user IDs in workspace
+    var userList = await getUsersInWorkSpace(app, token);
+
+    // reset everyone's monthly points
+    for (var userID of userList) {
+        firestoreFuncs.resetMonthlyPoints(workspaceID, userID);
+    }
+
+	return null;
+});
+
+/*
+    getUsersInWorkSpace(app, token)
+
+    Returns a list of all user IDs (no bots) in a workspace.
+    Used in scheduleResetWeeklyPoints() and scheduleResetMonthlyPoints().
+        PARAMS:
+        app         - index.getBolt()
+        token       - bot token
+*/
+// Returns all user IDs in a workspace
+async function getUsersInWorkSpace(app, token) {
+    var userMembers = await app.client.users.list({
+        token: token
+    }).then((obj) => {
+        return obj.members;
+    }).catch((error) => {
+        console.log(error);
+    });
+
+    // get list of user IDs (ignoring bots)
+    var userList = [];
+    userMembers.forEach((user) => {
+        if (user.is_bot === false) {
+            userList.push(user.id);
+        }
+    });
+
+    return userList;
+}
+
+/*
+    getLeaderboards(app, token, workspaceID)
+
+    Returns an array containing the weekly and monthly leaderboards as strings.
+        PARAMS:
+        app         - index.getBolt()
+        token       - bot token
+        workspaceID - current workspace ID
+*/
+exports.getLeaderboards = async (app, token, workspaceID) => {
+    // get array of IDs and their weekly and monthly points
+    const rankingsArr = await firestoreFuncs.getRankings(workspaceID);
+
+    // get user real names (not IDs)
+    for (i = 0; i < rankingsArr.length; i++) {
+        var m = await app.client.users.info({
+            token: token,
+            user: rankingsArr[i]['id']
+        });
+        if (rankingsArr[i]['id'] !== undefined) {
+            rankingsArr[i]['id'] = m.user.real_name;
+        }
+    }
+
+    // get leaderboard strings
+    const weeklyLeaderboard = getWeeklyLeaderboardStr(rankingsArr);
+    const monthlyLeaderboard = getMonthlyLeaderboardStr(rankingsArr);
+
+    // return them in an array
+    return [weeklyLeaderboard, monthlyLeaderboard];
+}
+
+/*
+    getWeeklyLeaderboardStr(rankingsArr)
+
+    Returns the weekly leaderboard as a string.
+        PARAM:
+        rankingsArr - array that contains everyone in the workspace,
+                along with their user ID, weekly, and monthly points.
+*/
+function getWeeklyLeaderboardStr(rankingsArr) {
+    var rank, name, weeklyPoints;
+    var rankings = rankingsArr.sort(compareWeekly);
+    // if everyone has 0 points, just return this message
+    if (rankings[0]['weeklyPoints'] === 0) {
+        return "*Weekly Leaderboard*\n```No one is on the leaderboard!```";
+    }
+    var weeklyLeaderboard = "*Weekly Leaderboard*\n" + 
+                            "```Rank     Name                      Points\n";
+
+    for (var i = 0; i < rankings.length; i++) {
+        // do not show people who have 0 points
+        if (rankings[i]['weeklyPoints'] === 0) {
+            break;
+        }
+        num = i + 1;
+        if (num === 1) {
+            rank = "🥇";
+        } else if (num === 2) {
+            rank = "🥈";
+        } else if (num === 3) {
+            rank = "🥉";
+        } else {
+            rank = num + ".";
+        }
+        name = rankings[i]['id'];
+        weeklyPoints = String(rankings[i]['weeklyPoints']);
+        weeklyLeaderboard += rank + "       " + rightJustify(name, 25) + 
+                                " " + leftJustify(weeklyPoints, 4) + "\n";
+    }
+    weeklyLeaderboard += "```";
+
+    console.log("weeklyLeaderboard: " + weeklyLeaderboard);
+    return weeklyLeaderboard;
+}
+
+/*
+    compareMonthly(a, b)
+
+    Compares two objects by their weeklyPoints.
+    Used in getWeeklyLeaderboardStr().
+        PARAMS:
+        a - an object to be compared
+        b - another object to be compared
+*/
+function compareWeekly(a, b) {
+    if (a.weeklyPoints <= b.weeklyPoints) {
+        comparison = 1;
+    } else {
+        comparison = -1;
+    }
+    return comparison;
+}
+
+/*
+    getMonthlyLeaderboardStr(rankingsArr)
+
+    Returns the monthly leaderboard as a string.
+        PARAM:
+        rankingsArr - array that contains everyone in the workspace,
+                along with their user ID, weekly, and monthly points.
+*/
+function getMonthlyLeaderboardStr(rankingsArr) {
+    var rank, name, monthlyPoints;
+    var rankings = rankingsArr.sort(compareMonthly);
+    var currMonthStr = getMonthStr();
+    // if everyone has 0 points, just return this message
+    if (rankings[0]['monthlyPoints'] === 0) {
+        return "*" + currMonthStr + " Leaderboard*\n```No one is on the leaderboard!```";
+    }
+    var monthlyLeaderboard = "*" + currMonthStr + " Leaderboard*\n" +
+                             "```Rank     Name                      Points\n";
+
+    for (var i = 0; i < rankings.length; i++) {
+        // do not show people who have 0 points
+        if (rankings[i]['monthlyPoints'] === 0) {
+            break;
+        }
+        num = i + 1;
+        if (num === 1) {
+            rank = "🥇";
+        } else if (num === 2) {
+            rank = "🥈";
+        } else if (num === 3) {
+            rank = "🥉";
+        } else {
+            rank = num + ".";
+        }
+        name = rankings[i]['id'];
+        monthlyPoints = String(rankings[i]['monthlyPoints']);
+        monthlyLeaderboard += rank + "       " + rightJustify(name, 25) + 
+                                " " + leftJustify(monthlyPoints, 4) + "\n";
+    }
+    monthlyLeaderboard += "```";
+    console.log("monthlyLeaderboard: " + monthlyLeaderboard);
+    return monthlyLeaderboard;
+}
+
+/*
+    compareMonthly(a, b)
+
+    Compares two objects by their monthlyPoints.
+    Used in getMonthlyLeaderboardStr().
+        PARAMS:
+        a - an object to be compared
+        b - another object to be compared
+*/
+function compareMonthly(a, b) {
+    if (a.monthlyPoints <= b.monthlyPoints) {
+        comparison = 1;
+    } else {
+        comparison = -1;
+    }
+    return comparison;
+}
+
+/*
+    getMonthStr()
+
+    Returns the current month as a string.
+    Used in getMonthlyLeaderboardStr().
+*/
+function getMonthStr() {
+    var month = ["January", "February", "March", "April", "May", "June", "July",
+                    "August", "September", "October", "November", "December"];
+    var date = new Date();
+    var monthStr = month[date.getMonth()];
+    return monthStr;
+}
+
+/*
+    rightJustify(str, length)
+
+    Given any string and a length, pads the string with space 
+    characters to the right to make it have the desired length.
+        PARAMS:
+        str    - string to be padded
+        length - the desired length
+*/
+function rightJustify(str, len) {
+    var fill = [];
+    while (fill.length + str.length < len) {
+      fill[fill.length] = " ";
+    }
+    return str + fill.join('');
+}
+
+/*
+    leftJustify(str, length)
+
+    Given any string and a length, pads the string with space 
+    characters to the left to make it have the desired length.
+        PARAMS:
+        str    - string to be padded
+        length - the desired length
+*/
+function leftJustify(str, len) {
+    var fill = [];
+    while (fill.length + str.length < len) {
+      fill[fill.length] = " ";
+    }
+    return fill.join('') + str;
+}

--- a/functions/onBoard.js
+++ b/functions/onBoard.js
@@ -8,7 +8,7 @@ const app = index.getBolt();
 
 var days = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"];
 
-// Listen for slash command /setup which creates new channel alti-pairing, 
+// Listen for slash command /setup which creates new channel alti-pairing,
 // invites all users in workspace, and designate as active pairing channel
 app.command('/setup', async ({payload, body, ack, say, context}) => {
     ack();
@@ -39,7 +39,7 @@ app.action('pairing_channel_selected', async({body, ack, say, context}) => {
 async function createOnBoardingChannel(app, token, team_id, channelName) {
     try {
         var promises = [];
-        
+
         var channels = await app.client.conversations.list({
             token: token
         }).catch((error) => {
@@ -78,7 +78,7 @@ async function createOnBoardingChannel(app, token, team_id, channelName) {
 
             // invite people
             app.client.conversations.invite({
-                token: token, 
+                token: token,
                 channel: conversationObj.channel.id,
                 users: userString
             }).catch((error) => {
@@ -89,11 +89,11 @@ async function createOnBoardingChannel(app, token, team_id, channelName) {
             app.client.chat.postMessage({
                 token: token,
                 channel: conversationObj.channel.id,
-                text: `Hi everyone! This is where we'll pair you up to participate in quick 
+                text: `Hi everyone! This is where we'll pair you up to participate in quick
                         and fun warm up and cool down activities :)
                         (To opt out, just leave the channel.)`
             });
-            
+
             promises.push(firestoreFuncs.storeNewPairingChannel(team_id, conversationObj.channel.id));
 
             for (var userId in usersDict) {
@@ -102,7 +102,7 @@ async function createOnBoardingChannel(app, token, team_id, channelName) {
                     promises.push(firestoreFuncs.setCooldownTime(team_id, userId, "5:00 PM", day));
                 }
             }
-            
+
             // reset user's weekly and monthly points
             firestoreFuncs.resetWeeklyPoints(team_id,userId);
             firestoreFuncs.resetMonthlyPoints(team_id,userId);
@@ -132,10 +132,10 @@ async function boardExistingChannel(app, token, team_id, channelId) {
         app.client.chat.postMessage({
             token: token,
             channel: channelId,
-            text: `Hey I've just been added to this channel! Everyone here will participate in quick 
+            text: `Hey I've just been added to this channel! Everyone here will participate in quick
                     and fun warm up and cool down activities :)
                     `
-            
+
         });
         // TODO (To opt out, just leave the channel.)
         await firestoreFuncs.storeNewPairingChannel(team_id, channelId);
@@ -144,7 +144,7 @@ async function boardExistingChannel(app, token, team_id, channelId) {
                 promises.push(firestoreFuncs.setWarmupTime(team_id, userId, "9:00 AM", day));
                 promises.push(firestoreFuncs.setCooldownTime(team_id, userId, "5:00 PM", day));
             }
-            
+
             // reset everyone's weekly and monthly points
             firestoreFuncs.resetWeeklyPoints(team_id,userId);
             firestoreFuncs.resetMonthlyPoints(team_id,userId);
@@ -177,7 +177,7 @@ async function findUsersWorkSpace(app, token) {
             usersDict[id] = u.name;
         }
     });
-    
+
     return usersDict;
 }
 
@@ -241,6 +241,10 @@ app.event('member_joined_channel', async ({ body, context }) => {
                 promises.push(firestoreFuncs.setCooldownTime(teamId, userId, "5:00 PM", day));
             }
         }
+
+        // reset user's weekly and monthly points upon joining
+        firestoreFuncs.resetWeeklyPoints(teamId,userId);
+        firestoreFuncs.resetMonthlyPoints(team_id,userId);
     }
 });
 
@@ -270,6 +274,10 @@ app.event('member_left_channel', async ({ body, context }) => {
         }).catch((error) => {
             console.log(error);
         });
+
+        // reset user's weekly and monthly points upon leave
+        firestoreFuncs.resetWeeklyPoints(teamId,userId);
+        firestoreFuncs.resetMonthlyPoints(team_id,userId);
 });
 
 

--- a/functions/onBoard.js
+++ b/functions/onBoard.js
@@ -8,7 +8,7 @@ const app = index.getBolt();
 
 var days = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"];
 
-// Listen for slash command /setup which creates new channel alti-pairing,
+// Listen for slash command /setup which creates new channel alti-pairing, 
 // invites all users in workspace, and designate as active pairing channel
 app.command('/setup', async ({payload, body, ack, say, context}) => {
     ack();
@@ -39,7 +39,7 @@ app.action('pairing_channel_selected', async({body, ack, say, context}) => {
 async function createOnBoardingChannel(app, token, team_id, channelName) {
     try {
         var promises = [];
-
+        
         var channels = await app.client.conversations.list({
             token: token
         }).catch((error) => {
@@ -78,7 +78,7 @@ async function createOnBoardingChannel(app, token, team_id, channelName) {
 
             // invite people
             app.client.conversations.invite({
-                token: token,
+                token: token, 
                 channel: conversationObj.channel.id,
                 users: userString
             }).catch((error) => {
@@ -89,11 +89,11 @@ async function createOnBoardingChannel(app, token, team_id, channelName) {
             app.client.chat.postMessage({
                 token: token,
                 channel: conversationObj.channel.id,
-                text: `Hi everyone! This is where we'll pair you up to participate in quick
+                text: `Hi everyone! This is where we'll pair you up to participate in quick 
                         and fun warm up and cool down activities :)
                         (To opt out, just leave the channel.)`
             });
-
+            
             promises.push(firestoreFuncs.storeNewPairingChannel(team_id, conversationObj.channel.id));
 
             for (var userId in usersDict) {
@@ -102,8 +102,11 @@ async function createOnBoardingChannel(app, token, team_id, channelName) {
                     promises.push(firestoreFuncs.setCooldownTime(team_id, userId, "5:00 PM", day));
                 }
             }
+            
+            // reset user's weekly and monthly points
             firestoreFuncs.resetWeeklyPoints(team_id,userId);
             firestoreFuncs.resetMonthlyPoints(team_id,userId);
+
             Promise.all(promises).catch((error) => {
                 console.log(error);
             });
@@ -129,10 +132,10 @@ async function boardExistingChannel(app, token, team_id, channelId) {
         app.client.chat.postMessage({
             token: token,
             channel: channelId,
-            text: `Hey I've just been added to this channel! Everyone here will participate in quick
+            text: `Hey I've just been added to this channel! Everyone here will participate in quick 
                     and fun warm up and cool down activities :)
                     `
-
+            
         });
         // TODO (To opt out, just leave the channel.)
         await firestoreFuncs.storeNewPairingChannel(team_id, channelId);
@@ -141,6 +144,8 @@ async function boardExistingChannel(app, token, team_id, channelId) {
                 promises.push(firestoreFuncs.setWarmupTime(team_id, userId, "9:00 AM", day));
                 promises.push(firestoreFuncs.setCooldownTime(team_id, userId, "5:00 PM", day));
             }
+            
+            // reset everyone's weekly and monthly points
             firestoreFuncs.resetWeeklyPoints(team_id,userId);
             firestoreFuncs.resetMonthlyPoints(team_id,userId);
         }
@@ -172,7 +177,7 @@ async function findUsersWorkSpace(app, token) {
             usersDict[id] = u.name;
         }
     });
-
+    
     return usersDict;
 }
 
@@ -200,7 +205,7 @@ app.event('member_joined_channel', async ({ body, context }) => {
         var userId = body.event.user;
         var teamId = body.team_id;
         console.log("Member joined pairing channel");
-        
+
         var conversation = await app.client.conversations.open({
             token: context.botToken,
             users: userId

--- a/functions/onBoard.js
+++ b/functions/onBoard.js
@@ -101,11 +101,10 @@ async function createOnBoardingChannel(app, token, team_id, channelName) {
                     promises.push(firestoreFuncs.setWarmupTime(team_id, userId, "9:00 AM", day));
                     promises.push(firestoreFuncs.setCooldownTime(team_id, userId, "5:00 PM", day));
                 }
+                // reset everyone's weekly and monthly points
+                firestoreFuncs.resetWeeklyPoints(team_id,userId);
+                firestoreFuncs.resetMonthlyPoints(team_id,userId);
             }
-            
-            // reset user's weekly and monthly points
-            promises.push(firestoreFuncs.resetWeeklyPoints(team_id,userId));
-            promises.push(firestoreFuncs.resetMonthlyPoints(team_id,userId));
             
             Promise.all(promises).catch((error) => {
                 console.log(error);

--- a/functions/onBoard.js
+++ b/functions/onBoard.js
@@ -8,7 +8,7 @@ const app = index.getBolt();
 
 var days = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"];
 
-// Listen for slash command /setup which creates new channel alti-pairing,
+// Listen for slash command /setup which creates new channel alti-pairing, 
 // invites all users in workspace, and designate as active pairing channel
 app.command('/setup', async ({payload, body, ack, say, context}) => {
     ack();
@@ -39,7 +39,7 @@ app.action('pairing_channel_selected', async({body, ack, say, context}) => {
 async function createOnBoardingChannel(app, token, team_id, channelName) {
     try {
         var promises = [];
-
+        
         var channels = await app.client.conversations.list({
             token: token
         }).catch((error) => {
@@ -78,7 +78,7 @@ async function createOnBoardingChannel(app, token, team_id, channelName) {
 
             // invite people
             app.client.conversations.invite({
-                token: token,
+                token: token, 
                 channel: conversationObj.channel.id,
                 users: userString
             }).catch((error) => {
@@ -89,11 +89,11 @@ async function createOnBoardingChannel(app, token, team_id, channelName) {
             app.client.chat.postMessage({
                 token: token,
                 channel: conversationObj.channel.id,
-                text: `Hi everyone! This is where we'll pair you up to participate in quick
+                text: `Hi everyone! This is where we'll pair you up to participate in quick 
                         and fun warm up and cool down activities :)
                         (To opt out, just leave the channel.)`
             });
-
+            
             promises.push(firestoreFuncs.storeNewPairingChannel(team_id, conversationObj.channel.id));
 
             for (var userId in usersDict) {
@@ -102,11 +102,11 @@ async function createOnBoardingChannel(app, token, team_id, channelName) {
                     promises.push(firestoreFuncs.setCooldownTime(team_id, userId, "5:00 PM", day));
                 }
             }
-
+            
             // reset user's weekly and monthly points
             firestoreFuncs.resetWeeklyPoints(team_id,userId);
             firestoreFuncs.resetMonthlyPoints(team_id,userId);
-
+            
             Promise.all(promises).catch((error) => {
                 console.log(error);
             });
@@ -132,10 +132,10 @@ async function boardExistingChannel(app, token, team_id, channelId) {
         app.client.chat.postMessage({
             token: token,
             channel: channelId,
-            text: `Hey I've just been added to this channel! Everyone here will participate in quick
+            text: `Hey I've just been added to this channel! Everyone here will participate in quick 
                     and fun warm up and cool down activities :)
                     `
-
+            
         });
         // TODO (To opt out, just leave the channel.)
         await firestoreFuncs.storeNewPairingChannel(team_id, channelId);
@@ -144,7 +144,7 @@ async function boardExistingChannel(app, token, team_id, channelId) {
                 promises.push(firestoreFuncs.setWarmupTime(team_id, userId, "9:00 AM", day));
                 promises.push(firestoreFuncs.setCooldownTime(team_id, userId, "5:00 PM", day));
             }
-
+            
             // reset everyone's weekly and monthly points
             firestoreFuncs.resetWeeklyPoints(team_id,userId);
             firestoreFuncs.resetMonthlyPoints(team_id,userId);
@@ -177,7 +177,7 @@ async function findUsersWorkSpace(app, token) {
             usersDict[id] = u.name;
         }
     });
-
+    
     return usersDict;
 }
 
@@ -241,11 +241,10 @@ app.event('member_joined_channel', async ({ body, context }) => {
                 promises.push(firestoreFuncs.setCooldownTime(teamId, userId, "5:00 PM", day));
             }
         }
-
-        // reset user's weekly and monthly points upon joining
+    }
+    // reset user's weekly and monthly points upon joining
         firestoreFuncs.resetWeeklyPoints(teamId,userId);
         firestoreFuncs.resetMonthlyPoints(team_id,userId);
-    }
 });
 
 app.event('member_left_channel', async ({ body, context }) => {
@@ -274,8 +273,7 @@ app.event('member_left_channel', async ({ body, context }) => {
         }).catch((error) => {
             console.log(error);
         });
-
-        // reset user's weekly and monthly points upon leave
+    // reset user's weekly and monthly points upon leave
         firestoreFuncs.resetWeeklyPoints(teamId,userId);
         firestoreFuncs.resetMonthlyPoints(team_id,userId);
 });

--- a/functions/onBoard.js
+++ b/functions/onBoard.js
@@ -104,8 +104,8 @@ async function createOnBoardingChannel(app, token, team_id, channelName) {
             }
             
             // reset user's weekly and monthly points
-            firestoreFuncs.resetWeeklyPoints(team_id,userId);
-            firestoreFuncs.resetMonthlyPoints(team_id,userId);
+            promises.push(firestoreFuncs.resetWeeklyPoints(team_id,userId));
+            promises.push(firestoreFuncs.resetMonthlyPoints(team_id,userId));
             
             Promise.all(promises).catch((error) => {
                 console.log(error);
@@ -146,8 +146,8 @@ async function boardExistingChannel(app, token, team_id, channelId) {
             }
             
             // reset everyone's weekly and monthly points
-            firestoreFuncs.resetWeeklyPoints(team_id,userId);
-            firestoreFuncs.resetMonthlyPoints(team_id,userId);
+            promises.push(firestoreFuncs.resetWeeklyPoints(team_id,userId));
+            promises.push(firestoreFuncs.resetMonthlyPoints(team_id,userId));
         }
         Promise.all(promises).catch((error) => {
             console.log(error);
@@ -242,9 +242,6 @@ app.event('member_joined_channel', async ({ body, context }) => {
             }
         }
     }
-    // reset user's weekly and monthly points upon joining
-        firestoreFuncs.resetWeeklyPoints(teamId,userId);
-        firestoreFuncs.resetMonthlyPoints(team_id,userId);
 });
 
 app.event('member_left_channel', async ({ body, context }) => {
@@ -273,9 +270,6 @@ app.event('member_left_channel', async ({ body, context }) => {
         }).catch((error) => {
             console.log(error);
         });
-    // reset user's weekly and monthly points upon leave
-        firestoreFuncs.resetWeeklyPoints(teamId,userId);
-        firestoreFuncs.resetMonthlyPoints(team_id,userId);
 });
 
 

--- a/functions/onBoard.js
+++ b/functions/onBoard.js
@@ -200,14 +200,7 @@ app.event('member_joined_channel', async ({ body, context }) => {
         var userId = body.event.user;
         var teamId = body.team_id;
         console.log("Member joined pairing channel");
-<<<<<<< HEAD
-        // TODO
-        // 1. DM user with information about being in pairing channel
-        // 2. Store user's info in db
-        //firestoreFuncs.setWarmupTime(team_id, userId, "9:00 AM", day);
-        //firestoreFuncs.setCooldownTime(team_id, userId, "5:00 PM", day);
-=======
-
+        
         var conversation = await app.client.conversations.open({
             token: context.botToken,
             users: userId
@@ -243,7 +236,6 @@ app.event('member_joined_channel', async ({ body, context }) => {
                 promises.push(firestoreFuncs.setCooldownTime(teamId, userId, "5:00 PM", day));
             }
         }
->>>>>>> 5b4e6bd460ef8aadcc1827ba603844ab2c0b2be3
     }
 });
 


### PR DESCRIPTION
Added weekly and monthly leaderboards to the app home. Added weeklyPoints and monthlyPoints fields in Firestore for each user in each workspace as well as PubSub functions to reset the points.