### PR TITLE
Added a check that prevents setting warmup or cooldown times at 12:00…

### DIFF
--- a/functions/appHomeObjects.js
+++ b/functions/appHomeObjects.js
@@ -910,6 +910,27 @@ var modal =
   "private_metadata": "Shhhhhhhh"
 };
 
+var cant_select_12am = {
+  "type": "modal",
+  "callback_id": 'cant_select_12am',
+  "title": {
+    "type": "plain_text",
+    "text": "Sorry!"
+  },
+  "blocks": [
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "Sorry you can't select 12:00AM as a warmup or cooldown time :frowning:"
+      },
+    }
+  ],
+  "close": {
+    "type": "plain_text",
+    "text": "Cancel"
+  }
+};
 
 exports.times = times;
 exports.ampm = ampm;
@@ -920,4 +941,5 @@ exports.wednesday_custom_block = this.wednesday_custom_block;
 exports.thursday_custom_block = this.thursday_custom_block;
 exports.friday_custom_block = this.friday_custom_block;
 exports.modal = modal;
+exports.cant_select_12am = cant_select_12am;
 

--- a/functions/appHomeSchedule.js
+++ b/functions/appHomeSchedule.js
@@ -60,7 +60,19 @@ app.action('warmup_time2_selected', async({payload, ack}) => {
 app.action('warmup_time_set_button', async({ack, body, context}) => {
     ack();
     var proms = [];
+    console.log(warmupTime1);
+    console.log(warmupTime2);
     if (warmupTime1 !== null && warmupTime2 !== null) {
+        if (warmupTime1 === "12:00" && warmupTime2 === "AM") {
+            app.client.views.open({
+                token: context.botToken,
+                trigger_id: body.trigger_id,
+                view: appHomeObjects.cant_select_12am
+            }).catch((error) => {
+                console.log(error);
+            });
+            return;
+        }
         var t = warmupTime1 + " " + warmupTime2;
         // console.log(t);
         for (var i of days) {
@@ -89,6 +101,16 @@ app.action('cooldown_time_set_button', async({ack, body, context}) => {
     ack();
     var proms = [];
     if (cooldownTime1 !== null && cooldownTime2 !== null) {
+        if (cooldownTime1 === "12:00" && cooldownTime2 === "AM") {
+            app.client.views.open({
+                token: context.botToken,
+                trigger_id: body.trigger_id,
+                view: appHomeObjects.cant_select_12am
+            }).catch((error) => {
+                console.log(error);
+            });
+            return;
+        }
         var t = cooldownTime1 + " " + cooldownTime2;
         // console.log(t);
         for (var i of days) {
@@ -163,8 +185,20 @@ app.action('monday_set_button', async({body, ack, context}) => {
         warmupTimes.monAMPM !== null &&
         cooldownTimes.monTime !== null && 
         cooldownTimes.monAMPM !== null) {
-        // console.log(warmupTimes.monTime + " " + warmupTimes.monAMPM);
-        // console.log(cooldownTimes.monTime + " " + cooldownTimes.monAMPM);
+            console.log(warmupTimes.monTime);
+            console.log(warmupTimes.monAMPM);
+        if ((warmupTimes.monTime === "12:00" && warmupTimes.monAMPM === "AM") ||
+            (cooldownTimes.monTime === "12:00" && cooldownTimes.monAMPM === "AM")) {
+            app.client.views.push({
+                token: context.botToken,
+                trigger_id: body.trigger_id,
+                view: appHomeObjects.cant_select_12am
+            }).catch((error) => {
+                console.log(error);
+            });
+            resetTimeVariables();
+            return;
+        }
         var t1 = warmupTimes.monTime + " " + warmupTimes.monAMPM;
         var t2 = cooldownTimes.monTime + " " + cooldownTimes.monAMPM;
         var proms = [];
@@ -206,8 +240,18 @@ app.action('tuesday_set_button', async({body, ack, context}) => {
         warmupTimes.tuesAMPM !== null &&
         cooldownTimes.tuesTime !== null && 
         cooldownTimes.tuesAMPM !== null) {
-        // console.log(warmupTimes.tuesTime + " " + warmupTimes.tuesAMPM);
-        // console.log(cooldownTimes.tuesTime + " " + cooldownTimes.tuesAMPM);
+        if ((warmupTimes.tuesTime === "12:00" && warmupTimes.tuesAMPM === "AM") ||
+        (cooldownTimes.tuesTime === "12:00" && cooldownTimes.tuesAMPM === "AM") ) {
+            app.client.views.push({
+                token: context.botToken,
+                trigger_id: body.trigger_id,
+                view: appHomeObjects.cant_select_12am
+            }).catch((error) => {
+                console.log(error);
+            });
+            resetTimeVariables();
+            return;
+        }
         var t1 = warmupTimes.tuesTime + " " + warmupTimes.tuesAMPM;
         var t2 = cooldownTimes.tuesTime + " " + cooldownTimes.tuesAMPM;
         var proms = [];
@@ -248,8 +292,18 @@ app.action('wednesday_set_button', async({body, ack, context}) => {
         warmupTimes.wedAMPM !== null &&
         cooldownTimes.wedTime !== null && 
         cooldownTimes.wedAMPM !== null) {
-        // console.log(warmupTimes.wedTime + " " + warmupTimes.wedAMPM);
-        // console.log(cooldownTimes.wedTime + " " + cooldownTimes.wedAMPM);
+        if ((warmupTimes.wedTime === "12:00" && warmupTimes.wedAMPM === "AM") ||
+        (cooldownTimes.wedTime === "12:00" && cooldownTimes.wedAMPM === "AM")) {
+            app.client.views.push({
+                token: context.botToken,
+                trigger_id: body.trigger_id,
+                view: appHomeObjects.cant_select_12am
+            }).catch((error) => {
+                console.log(error);
+            });
+            resetTimeVariables();
+            return;
+        }
         var t1 = warmupTimes.wedTime + " " + warmupTimes.wedAMPM;
         var t2 = cooldownTimes.wedTime + " " + cooldownTimes.wedAMPM;
         var proms = [];
@@ -290,8 +344,18 @@ app.action('thursday_set_button', async({body, ack, context}) => {
         warmupTimes.thursAMPM !== null &&
         cooldownTimes.thursTime !== null && 
         cooldownTimes.thursAMPM !== null) {
-        console.log(warmupTimes.thursTime + " " + warmupTimes.thursAMPM);
-        console.log(cooldownTimes.thursTime + " " + cooldownTimes.thursAMPM);
+        if ((warmupTimes.thursTime === "12:00" && warmupTimes.thursAMPM === "AM") ||
+        (cooldownTimes.thursTime === "12:00" && cooldownTimes.thursAMPM === "AM")) {
+            app.client.views.push({
+                token: context.botToken,
+                trigger_id: body.trigger_id,
+                view: appHomeObjects.cant_select_12am
+            }).catch((error) => {
+                console.log(error);
+            });
+            resetTimeVariables();
+            return;
+        }
         var t1 = warmupTimes.thursTime + " " + warmupTimes.thursAMPM;
         var t2 = cooldownTimes.thursTime + " " + cooldownTimes.thursAMPM;
         var proms = [];
@@ -332,8 +396,18 @@ app.action('friday_set_button', async({body, ack, context}) => {
         warmupTimes.friAMPM !== null &&
         cooldownTimes.friTime !== null && 
         cooldownTimes.friAMPM !== null) {
-        console.log(warmupTimes.friTime + " " + warmupTimes.friAMPM);
-        console.log(cooldownTimes.friTime + " " + cooldownTimes.friAMPM);
+        if ((warmupTimes.friTime === "12:00" && warmupTimes.friAMPM === "AM") ||
+        (cooldownTimes.friTime === "12:00" && cooldownTimes.friAMPM === "AM")) {
+            app.client.views.push({
+                token: context.botToken,
+                trigger_id: body.trigger_id,
+                view: appHomeObjects.cant_select_12am
+            }).catch((error) => {
+                console.log(error);
+            });
+            resetTimeVariables();
+            return;
+        }
         var t1 = warmupTimes.friTime + " " + warmupTimes.friAMPM;
         var t2 = cooldownTimes.friTime + " " + cooldownTimes.friAMPM;
         var proms = [];

--- a/functions/onBoard.js
+++ b/functions/onBoard.js
@@ -138,10 +138,7 @@ async function boardExistingChannel(app, token, team_id, channelId) {
         });
         await firestoreFuncs.storeNewPairingChannel(team_id, channelId);
         for (var userId of userList) {
-            for (var day of days) {
-                promises.push(firestoreFuncs.setWarmupTime(team_id, userId, "9:00 AM", day));
-                promises.push(firestoreFuncs.setCooldownTime(team_id, userId, "5:00 PM", day));
-            }
+            safeSetSchedule(team_id, userId);
             
             // reset everyone's weekly and monthly points
             promises.push(firestoreFuncs.resetWeeklyPoints(team_id,userId));
@@ -154,7 +151,24 @@ async function boardExistingChannel(app, token, team_id, channelId) {
     catch (error) {
         console.log(error);
     }
+}
 
+async function safeSetSchedule(workspaceId, userId) {
+    var t = firestoreFuncs.getWarmupTime(workspaceId, userId, "Monday");
+    if (t !== undefined) {
+        return;
+    }
+    else {
+        var promises = [];
+        for (var day of days) {
+            promises.push(firestoreFuncs.setWarmupTime(team_id, userId, "9:00 AM", day));
+            promises.push(firestoreFuncs.setCooldownTime(team_id, userId, "5:00 PM", day));
+        }
+        Promise.all(promises).catch((error) => {
+            console.log(error);
+        });
+    }
+    
 }
 
 // Find the users within a workspace and return it as a dict of userId: userName

--- a/functions/pubsubScheduler.js
+++ b/functions/pubsubScheduler.js
@@ -258,14 +258,6 @@ async function scheduleDailyWorkspace(workspaceId) {
     scheduleDailyUser(workspaceId, m, w_token, day, threads);
   }
 
-  if (workspaceId === "T012US11G4X") {
-    var offset = new Date().getTimezoneOffset();
-    app.client.chat.postMessage({
-      token: w_token,
-      channel: channel,
-      text: "Timezone offset: " + offset + " minutes"
-    });
-  }
   /*
   // TESTING PURPOSES
   var temp = await app.client.chat.scheduledMessages.list({
@@ -302,11 +294,69 @@ async function scheduleDailyUser(workspaceId, userId, token, day, threads) {
     return null;
   }
 
+  // Schedule warmup and cooldown reminders at warmup and cooldown times
+  const warmupReminderMessage = "Hi there! It's time to start your work day so remember to get your warmup!";
+  const cooldownReminderMessage = "Hey there it's time to cool off and exit your workflow. Remember to grab your cooldown!";
+
+  var conversation = await app.client.conversations.open({
+    token: token,
+    users: userId
+  }).catch((error) => {
+      console.log(error);
+  });
+
+  if(!conversation.ok) {
+    console.log("Open DM failed!");
+}
+
   var warmupTask;
   var cooldownTask;
   var dmThreadID = pairingData.dmThreadID;
   var quote;
   var hour, min, mid;
+
+  split = warmupTime.split(" ");
+  hour = warmupTime.split(" ")[0].split(":")[0];
+  min = warmupTime.split(" ")[0].split(":")[1];
+  mid = warmupTime.split(" ")[1];
+  if (mid === "PM") {
+    hour = String(Number(hour) + 12);
+  }
+  else if (mid === "AM" && hour === "12") {
+    hour = "0";
+  }
+  if (test === 0) { 
+    console.log("Schedule warm up reminder for " + hour + ":" + min + " for userId " + `<@${  userId  }>`);
+    await schedule.scheduleMsg(hour, min, warmupReminderMessage, conversation.channel.id, token).catch((error) => {
+      console.log(error);
+    }); 
+  }
+  else {
+  // TESTING PURPOSES
+    schedule.scheduleMsg(19, 49, warmupReminderMessage, conversation.channel.id, token);
+  }
+
+  split = cooldownTime.split(" ");
+  hour = cooldownTime.split(" ")[0].split(":")[0];
+  min = cooldownTime.split(" ")[0].split(":")[1];
+  mid = cooldownTime.split(" ")[1];
+  if (mid === "PM" && hour !== "12") {
+    hour = String(Number(hour) + 12);
+  }
+  else if (mid === "AM" && hour === "12") {
+    hour = "0";
+  }
+  if (test === 0) {
+    console.log("Schedule cooldown reminder for " + hour + ":" + min + " for userId " + `<@${  userId  }>`);
+    await schedule.scheduleMsg(hour, min, cooldownReminderMessage, conversation.channel.id, token).catch((error) => {
+      console.log(error);
+    });
+  }
+  else {
+  // TESTING PURPOSES
+   await schedule.scheduleMsg(19, 49, cooldownReminderMessage, conversation.channel.id, token);
+  }
+  
 
   if (userId === threads[dmThreadID].warmupUser) {
     console.log("Warmup button is being sent for user " + `<@${  userId  }>` + " in thread " + dmThreadID);
@@ -332,7 +382,7 @@ async function scheduleDailyUser(workspaceId, userId, token, day, threads) {
     }
     else {
       // TESTING PURPOSES
-      await schedule.scheduleMsg(15, 27, warmupButtonText, dmThreadID, token, warmupMessage.getStartDayBlocks())
+      await schedule.scheduleMsg(19, 49, warmupButtonText, dmThreadID, token, warmupMessage.getStartDayBlocks())
       .catch((error) => {
         console.error(error);
       });     
@@ -362,7 +412,7 @@ async function scheduleDailyUser(workspaceId, userId, token, day, threads) {
     else {
       // TESTING PURPOSES
       
-      await schedule.scheduleMsg(15, 27, exerciseSelectNotificationText, dmThreadID, token, warmupMessage.getEndDayBlocks())
+      await schedule.scheduleMsg(19, 49, exerciseSelectNotificationText, dmThreadID, token, warmupMessage.getEndDayBlocks())
               .catch((err) => {
                 console.error(err);
               });


### PR DESCRIPTION
Added sending reminders as a dm from Alti at the user's cooldown and warmup times. Added check the prevents selecting 12AM as warmup or cooldown. The user will get a popup that says "sorry! can't select 12:00AM as a warmup or cooldown time". Now doesn't reset a user's schedule to 9am-5pm if the user schedule exists already when selecting a new pairing channel