### PR TITLE
Fixed change pairing channel bug

### DIFF
--- a/functions/slackFunctionality/appHome.js
+++ b/functions/slackFunctionality/appHome.js
@@ -594,7 +594,7 @@ async function loadHomeTabUI(app, workspaceID, userId, context) {
 						},
 						"text": {
 							"type": "plain_text",
-							"text": "❗️*NOTE*❗️: The pairing channel will be changed on Sunday. Switching your pairing channel will remove all data previously associated with that channel. Also, users that were in the previous pairing channel will not be transferred over to the new one; they will have to manually join the channel."
+							"text": "❗️*NOTE*❗️: The pairing channel will be changed on Sunday. Switching your pairing channel will remove all data previously associated with that channel. Also, users that were in the previous pairing channel will not be transferred over to the new one."
 						},
 						"confirm": {
 							"type": "plain_text",

--- a/functions/slackFunctionality/changePairingChannel.js
+++ b/functions/slackFunctionality/changePairingChannel.js
@@ -6,6 +6,7 @@ const app = index.getBolt();
 
 /*
     scheduleChangePairingChannel
+
     If the owner selected a new pairing channel during the week,
     switches pairing channels at 12:55 PM Pacific Time
     (before scheduledPairUp runs).
@@ -34,12 +35,14 @@ exports.scheduleChangePairingChannel = functions.pubsub
 }
 
 /*
-changePairingChannelHelper(workspaceID, apiPair)
-Changes the pairing channel in a given workspace
-(if it was requested to be changed mid-week).
-Inputs:
-    workspaceID - the workspace ID
-    apiPair - API pair for the workspace
+    changePairingChannelHelper(workspaceID, apiPair)
+
+    Changes the pairing channel in a given workspace
+    (if it was requested to be changed mid-week).
+    
+    Inputs:
+        workspaceID - the workspace ID
+        apiPair - API pair for the workspace
 */
 async function changePairingChannelHelper(workspaceID, apiPair) {
     if (apiPair !== null) {

--- a/functions/slackFunctionality/changePairingChannel.js
+++ b/functions/slackFunctionality/changePairingChannel.js
@@ -6,7 +6,6 @@ const app = index.getBolt();
 
 /*
     scheduleChangePairingChannel
-
     If the owner selected a new pairing channel during the week,
     switches pairing channels at 12:55 PM Pacific Time
     (before scheduledPairUp runs).
@@ -36,10 +35,8 @@ exports.scheduleChangePairingChannel = functions.pubsub
 
 /*
 changePairingChannelHelper(workspaceID, apiPair)
-
 Changes the pairing channel in a given workspace
 (if it was requested to be changed mid-week).
-
 Inputs:
     workspaceID - the workspace ID
     apiPair - API pair for the workspace
@@ -73,4 +70,4 @@ async function changePairingChannelHelper(workspaceID, apiPair) {
     }
     promise.catch(err => console.error(err));
     await promise;
-});
+}); 

--- a/functions/slackFunctionality/index.js
+++ b/functions/slackFunctionality/index.js
@@ -45,7 +45,6 @@ exports.scheduleResetWeeklyPoints = leaderboard.scheduleResetWeeklyPoints;
 exports.scheduleResetMonthlyPoints = leaderboard.scheduleResetMonthlyPoints;
 exports.scheduleChangePairingChannel = changePairingChannel.scheduleChangePairingChannel;
 
-
 //Test Ruixian 
 exports.test1 = pubsubScheduler.test1;
 //

--- a/functions/slackFunctionality/index.js
+++ b/functions/slackFunctionality/index.js
@@ -45,6 +45,7 @@ exports.scheduleResetWeeklyPoints = leaderboard.scheduleResetWeeklyPoints;
 exports.scheduleResetMonthlyPoints = leaderboard.scheduleResetMonthlyPoints;
 exports.scheduleChangePairingChannel = changePairingChannel.scheduleChangePairingChannel;
 
+
 //Test Ruixian 
 exports.test1 = pubsubScheduler.test1;
 //


### PR DESCRIPTION
Now allows you to actually choose a pairing channel from the drop-down menu. I think the issue was just that I was trying to fit too much text inside a modal.